### PR TITLE
Make the PixiJS renderer preference configurable

### DIFF
--- a/packages/pixi-svelte/src/lib/components/App.svelte
+++ b/packages/pixi-svelte/src/lib/components/App.svelte
@@ -7,7 +7,7 @@
 	import InitialiseParent from './InitialiseParent.svelte';
 	import AssetsLoader from './AssetsLoader.svelte';
 
-	type Props = { children: Snippet };
+	type Props = { children: Snippet; rendererPreference?: 'webgpu' | 'webgl' };
 
 	const props: Props = $props();
 	const context = getContextApp();
@@ -16,7 +16,7 @@
 	onDestroy(() => context.stateApp.reset());
 </script>
 
-<InitialiseApplication>
+<InitialiseApplication rendererPreference={props.rendererPreference}>
 	<InitialiseParent>
 		<AssetsLoader>
 			{@render props.children()}

--- a/packages/pixi-svelte/src/lib/components/InitialiseApplication.svelte
+++ b/packages/pixi-svelte/src/lib/components/InitialiseApplication.svelte
@@ -6,7 +6,7 @@
 	import { getContextApp } from '../context.svelte';
 	import { preloadFont } from '../utils.svelte';
 
-	type Props = { children: Snippet };
+	type Props = { children: Snippet; rendererPreference?: 'webgpu' | 'webgl' };
 
 	const props: Props = $props();
 	const context = getContextApp();
@@ -26,7 +26,7 @@
 			multiView: false,
 			antialias: true,
 			clearBeforeRender: true,
-			preference: 'webgpu',
+			preference: props.rendererPreference ?? 'webgpu',
 			powerPreference: 'high-performance',
 			resolution: devicePixelRatio.current,
 			resizeTo: window,


### PR DESCRIPTION
## Problem

`InitialiseApplication.svelte` hardcodes the PixiJS renderer preference:

```js
preference: 'webgpu',
```

On a machine where WebGPU is *available* but produces no output, every sample
game is a black screen. There is no error, in the console or anywhere else —
the app authenticates, assets load, the scene graph builds and the ticker runs.
Only nothing is drawn.

Observed on Windows 11 / Chrome, with the `scatter` sample connected to a live
RGS session:

| | `preference: 'webgpu'` | `preference: 'webgl'` |
|---|---|---|
| canvas context | `webgpu` | `webgl2` |
| `renderer.type` | 2 | 1 |
| `stage.children` | 4 | 9 |
| `ticker.started` | true | true |
| what you see | black screen | the game |

The state that makes this hard to diagnose is the middle rows: the renderer
reports the right size, the stage has children, and the ticker is running, so
every health check short of looking at the pixels passes.

PixiJS already falls back to WebGL when WebGPU is **unavailable**. It cannot
fall back here, because WebGPU reports itself as working — so the choice has to
be made from outside.

## Change

Expose an optional `rendererPreference` prop, threaded from `App` through to
`InitialiseApplication`:

```js
preference: props.rendererPreference ?? 'webgpu',
```

Nothing changes by default. A game that hits this can now opt out with

```svelte
<App rendererPreference="webgl">
```

instead of patching `pixi-svelte` in `node_modules` or forking the package,
which is what is required today.

## Notes

The default stays `'webgpu'` deliberately — this is not an argument that WebGPU
is the wrong default, only that there needs to be a way out of it that does not
involve editing the package. If you would rather this were driven by an env var
(`PUBLIC_RENDERER_PREFERENCE`) or auto-detected with a render probe, I am happy
to redo it that way.

Two files, +2 −2.
