### PR TITLE
Derive bet modes from the RGS instead of the placeholder table

### DIFF
--- a/packages/components-shared/src/components/Authenticate.svelte
+++ b/packages/components-shared/src/components/Authenticate.svelte
@@ -2,7 +2,15 @@
 	import { onMount, type Snippet } from 'svelte';
 
 	import { requestAuthenticate, requestReplay } from 'rgs-requests';
-	import { stateUrlDerived, stateBet, stateConfig, stateModal, stateUi } from 'state-shared';
+	import {
+		stateUrlDerived,
+		stateBet,
+		stateConfig,
+		stateMeta,
+		stateModal,
+		stateUi,
+		reconcileBetModeMeta,
+	} from 'state-shared';
 	import { API_AMOUNT_MULTIPLIER, MOST_USED_BET_INDEXES } from 'constants-shared/bet';
 
 	type Props = { children: Snippet };
@@ -66,6 +74,15 @@
 				stateConfig.betMenuOptions = stateConfig.betAmountOptions.filter((_, index) =>
 					MOST_USED_BET_INDEXES.includes(index),
 				);
+
+				// Example of authenticateData.config.gameModes
+				// [
+				// 	{ "mode": "base", "costMultiplier": 1, "maxBet": 2000000000 },
+				// 	{ "mode": "bonus", "costMultiplier": 200, "maxBet": 2000000000 }
+				// ]
+				if (authenticateData.config?.gameModes?.length) {
+					stateMeta.betModeMeta = reconcileBetModeMeta(authenticateData.config.gameModes);
+				}
 			}
 
 			// round

--- a/packages/state-shared/src/stateMeta.svelte.ts
+++ b/packages/state-shared/src/stateMeta.svelte.ts
@@ -59,3 +59,35 @@ export const stateMeta = $state({
 export const stateMetaDerived = {
 	betModeMetaList: () => Object.values(stateMeta.betModeMeta),
 };
+
+/**
+ * Reconcile `betModeMeta` against the bet modes the RGS reports at authentication.
+ *
+ * `betModeMeta` defaults to a placeholder table that does not describe any
+ * particular game. Modes it lists that the RGS does not know are rejected with
+ * ERR_VAL "invalid amount" when played, and a costMultiplier that disagrees with
+ * the published math is wrong in the UI before it is ever sent.
+ *
+ * Server-reported modes win on identity and cost; presentation a game has already
+ * set (assets, copy, type) is kept for the modes that survive.
+ */
+export const reconcileBetModeMeta = (
+	gameModes: { mode: string; costMultiplier: number }[],
+): BetModeMeta => {
+	const reconciled: BetModeMeta = {};
+
+	gameModes.forEach(({ mode, costMultiplier }) => {
+		const key = mode.toUpperCase();
+		const existing = stateMeta.betModeMeta[key] ?? stateMeta.betModeMeta[mode.toLowerCase()];
+
+		reconciled[key] = {
+			...(existing ?? DEFAULT_BET_MODE_META.BASE),
+			mode: key,
+			costMultiplier,
+			// only infer when the game has not described this mode itself
+			type: existing?.type ?? (costMultiplier === 1 ? 'default' : 'buy'),
+		} as BetModeData;
+	});
+
+	return reconciled;
+};


### PR DESCRIPTION
## Problem

`stateMeta.betModeMeta` defaults to `DEFAULT_BET_MODE_META` in
`state-shared/src/constants.ts`:

| mode | costMultiplier | type |
|---|---|---|
| BASE | 1.0 | default |
| ANTE | 1.2 | activate |
| SUPERANTE | 5 | activate |
| SUPERSPIN | 25 | activate |
| BONUS | 100 | buy |
| SUPER | 200 | buy |

That table describes no particular game, and **nothing overrides it** — none of
the six sample apps assign `betModeMeta`. So every game ships the same six modes
in its buy/activate dialog regardless of what its math actually published.

Reproduced with the `scatter` sample against a live RGS session. Its math
declares exactly two modes (`base` cost 1.0, `bonus` cost 200), but the dialog
offered six. Pressing a buy option returned:

```
ERR_VAL   "invalid amount"
```

Two distinct failures are folded together here:

1. **Modes that do not exist.** ANTE, SUPERANTE, SUPERSPIN and SUPER are not in
   this game's math. The RGS rejects them.
2. **A cost that disagrees.** `BONUS` is declared at 100x, while the published
   math has it at 200x. Even for a real mode, the dialog shows the wrong price
   before any request is sent.

## The fix

`/wallet/authenticate` already returns the authoritative list:

```json
"gameModes": [
  { "mode": "base",  "costMultiplier": 1,   "maxBet": 2000000000 },
  { "mode": "bonus", "costMultiplier": 200, "maxBet": 2000000000 }
]
```

`Authenticate.svelte` already consumes `config` for `betLevels` and
`jurisdiction` — it just ignores `gameModes`. This reconciles against it in the
same place:

```js
if (authenticateData.config?.gameModes?.length) {
    stateMeta.betModeMeta = reconcileBetModeMeta(authenticateData.config.gameModes);
}
```

`reconcileBetModeMeta` (new, in `state-shared`) keeps only the modes the server
reports, takes `costMultiplier` from the server, and preserves any presentation
a game has already set — assets, copy, and `type` — for the modes that survive.
`type` is only inferred (`costMultiplier === 1 ? 'default' : 'buy'`) for a
server mode the game has not described itself.

Deriving from the server rather than from each game's local config means this
cannot drift from what the RGS will actually accept, and it fixes all six
samples without per-app wiring.

## Verification

Against a live session, `scatter`, with the buy dialog opened:

| | before | after |
|---|---|---|
| modes offered | 6 (3 activate, 2 buy, + base) | **1** (BONUS) |
| bonus price shown | $100.00 | **$200.00** |
| pressing buy | `ERR_VAL "invalid amount"` | round plays |
| existing copy | — | preserved ("Each spin may have a random multiplier applied to winning lines.") |

A full bonus round then settled correctly end to end — $992.00 → $792.00 on the
buy, freespins with a global multiplier, → $842.40 on payout.

## Note

The placeholder table is left in place as the pre-authentication default, so
nothing changes for a game that sets its own meta before this runs, and the
dialog still has something to render if `gameModes` is absent. If you would
rather the default table were dropped entirely, or that this live in a derived
value rather than an assignment, happy to redo it.
