### PR TITLE
Map the book event game type onto the frontend's vocabulary

### DIFF
--- a/apps/scatter/src/game/bookEventHandlerMap.ts
+++ b/apps/scatter/src/game/bookEventHandlerMap.ts
@@ -8,7 +8,17 @@ import { playBookEvent } from './utils';
 import { winLevelMap, type WinLevel, type WinLevelData } from './winLevelMap';
 import { stateGame, stateGameDerived } from './stateGame.svelte';
 import type { BookEvent, BookEventOfType, BookEventContext } from './typesBookEvent';
-import type { Position } from './types';
+import type { GameType, Position } from './types';
+
+/**
+ * math-sdk names its game types basegame / freegame (Config.freegame_type), while this
+ * game's config - and therefore GameType - names them basegame / freeSpins. Passing the
+ * book event's value through raw leaves gameType at 'freegame', which matches neither
+ * branch in Background.svelte, so both backgrounds stay hidden and the screen goes black
+ * for the whole feature. freeSpinTrigger sets the right value; the next reveal overwrote it.
+ */
+const toGameType = (raw: string): GameType =>
+	raw === 'freegame' ? 'freeSpins' : (raw as GameType);
 
 const winLevelSoundsPlay = ({ winLevelData }: { winLevelData: WinLevelData }) => {
 	if (winLevelData?.alias === 'max') eventEmitter.broadcastAsync({ type: 'uiHide' });
@@ -51,7 +61,7 @@ export const bookEventHandlerMap: BookEventHandlerMap<BookEvent, BookEventContex
 			recordBookEvent({ bookEvent });
 		}
 
-		stateGame.gameType = bookEvent.gameType;
+		stateGame.gameType = toGameType(bookEvent.gameType);
 		await stateGameDerived.enhancedBoard.spin({ revealEvent: bookEvent });
 		eventEmitter.broadcast({ type: 'soundScatterCounterClear' });
 	},


### PR DESCRIPTION
## Problem

The whole free spins feature plays on a black screen: no background at all,
base or feature. The scene reappears the instant the round ends.

`Background.svelte` picks the scene from `stateGame.gameType`:

```ts
const showBaseBackground    = $derived(context.stateGame.gameType === 'basegame');
const showFeatureBackground = $derived(context.stateGame.gameType === 'freeSpins');
```

`bookEventHandlerMap.ts` assigns that value straight from the book event:

```ts
reveal: async (bookEvent, { bookEvents }) => {
    ...
    stateGame.gameType = bookEvent.gameType;
```

But the two SDKs do not agree on the vocabulary:

| | base | feature |
|---|---|---|
| math-sdk — `Config` in `src/config/config.py` | `basegame` | **`freegame`** |
| this app — keys of `config.paddingReels`, which is what `GameType` is derived from | `basegame` | **`freeSpins`** |

So during a feature round `gameType` is `'freegame'`, which matches neither
branch. Both `FadeContainer`s stay hidden and what shows through is the black
`Rectangle` behind them.

`freeSpinTrigger` does set the correct value:

```ts
stateGame.gameType = 'freeSpins';
```

…but the next `reveal` immediately overwrites it. And `freeSpinEnd` sets
`'basegame'`, which is exactly why the background comes back the moment the
round finishes — the scene that returns is the *base* one, not the feature one,
so the feature scene is never seen at all.

Measured against the published books for `0_0_scatter`:

```
books_bonus : 4060 reveal events with gameType 'freegame'
books_base  :  400 reveal events with gameType 'basegame'
```

`GameType` cannot catch this: the book event is parsed from JSON, so the raw
string flows in untyped.

## Change

Map the incoming value onto the frontend's vocabulary at the point of
assignment:

```ts
const toGameType = (raw: string): GameType =>
	raw === 'freegame' ? 'freeSpins' : (raw as GameType);
```

Nothing else changes — `freeSpinTrigger` and `freeSpinEnd` already assign the
right literals directly.

## Scope

This is not specific to one game. `basegame` / `freegame` are the math-sdk
defaults, so any game whose frontend config names the feature `freeSpins` has
the same silent failure. The other samples in this repo are worth a look; I
only had `scatter` set up against a live RGS session to confirm it.

If you would rather fix it the other way — rename the config key to `freegame`
so the two SDKs agree — that works too, but it changes `GameType` and every
`'freeSpins'` literal in the app, so I went with the narrower change.
